### PR TITLE
Make adjustments for standalone canvas parser and remove extra functions

### DIFF
--- a/dart_canvas_parser/canvas_api.py
+++ b/dart_canvas_parser/canvas_api.py
@@ -1,231 +1,96 @@
 import json
 import requests
-
 from django.conf import settings
-
 from canvas_sdk.exceptions import (CanvasAPIError, InvalidOAuthTokenError)
 from canvas_sdk.methods import courses, pages, quizzes, quiz_questions, \
     enrollments, users, modules
 from canvas_sdk.utils import get_all_list_data
 from canvas_sdk import RequestContext
-
 import logging
+
 
 log = logging.getLogger('dart')
 
 
-def _sdk_call(user_model, function, **kwargs):
-    if user_model.refresh_token and not user_model.api_token:
-        log.info("No API token for user {}".format(user_model.user_uid))
-        _refresh_api_token(user_model)
-    context = _get_context(user_model.api_token)
-    try:
+CANVAS_SDK_SETTINGS = dict(
+    max_retries = 3,
+    per_page = 40,
+)
+
+
+class CanvasApi(object):
+    def __init__(self, url_base, api_token):
+        self.url_base = url_base
+        self.api_token = api_token
+
+
+    def _sdk_call(self, function, **kwargs):
+        context = self._get_context(self.api_token)
         return function(context, **kwargs)
-    except InvalidOAuthTokenError:
-        log.info(
-            "Invalid or expired API token for user {}".format(
-                user_model.user_uid)
+
+
+    def get_course(self, course_id):
+        return self._sdk_call(self._get_course, course_id=course_id)
+
+
+    @staticmethod
+    def _get_course(context, course_id):
+        url = "{}/v1/courses/{}?include[]=syllabus_body&include[]=term".format(
+            context.base_api_url, course_id
         )
-        _refresh_api_token(user_model)
-        context = _get_context(user_model.api_token)
-        return function(context, **kwargs)
-
-
-def _refresh_api_token(user_model):
-    user_model.api_token = None
-    try:
-        if user_model.refresh_token:
-            url = '{}/login/oauth2/token'.format(settings.CANVAS_URL_BASE)
-            log.info("Refreshing token from URL {}".format(url))
-            data = {
-                'grant_type': 'refresh_token',
-                'client_id': settings.CANVAS_OAUTH_CLIENT_ID,
-                'client_secret': settings.CANVAS_OAUTH_CLIENT_KEY,
-                'refresh_token': user_model.refresh_token
-            }
-            headers = {
-                'Content-Type': 'application/json',
-            }
-            response = requests.post(url, json.dumps(data), headers=headers)
-            if response.status_code != 200:
-                raise CanvasAPIError(
-                    status_code=response.status_code,
-                    msg=u"Error from {}: {}".format(url, response.text)
-                )
-            user_model.api_token = response.json()['access_token']
-            log.info(
-                "Refreshed API token for user {}".format(user_model.user_uid)
+        response = requests.get(
+            url, headers={"Authorization": "Bearer {}".format(context.auth_token)}
+        )
+        if response.status_code != 200:
+            if response.status_code == 401 and 'WWW-Authenticate' in response.headers:
+                raise InvalidOAuthTokenError(
+                    "OAuth Token used to make request to %s is invalid" % response.url)
+            raise CanvasAPIError(
+                status_code=response.status_code,
+                msg=unicode(response.json()),
+                error_json=response.json(),
             )
-    finally:
-        user_model.save()
+        return response.json()
 
 
-def check_token(user_model):
-    return _sdk_call(user_model, _check_token)
+    def get_pages(self, course_id):
+        return self._sdk_call(self._get_pages, course_id=course_id)
 
 
-def _check_token(context):
-    log.info("Getting profile")
-    users.get_user_profile(context, 'self').json()
-    log.info("Fetched profile")
-    return True
-
-
-def get_all_courses(user_model):
-    return _sdk_call(user_model, _get_all_courses)
-
-
-def _get_all_courses(context):
-    lst = get_all_list_data(
-        context,
-        enrollments.list_enrollments_users,
-        user_id='self',
-        state='completed',
-        type=['TeacherEnrollment', 'TaEnrollment', 'ObserverEnrollment',
-              'DesignerEnrollment'],
-    )
-    lst += get_all_list_data(
-        context,
-        enrollments.list_enrollments_users,
-        user_id='self',
-        state='active',
-        type=['TeacherEnrollment', 'TaEnrollment', 'ObserverEnrollment',
-              'DesignerEnrollment'],
-    )
-    course_list = []
-    for e in lst:
-        course_list.append(_get_course(context, e['course_id']))
-    return course_list
-
-
-def get_active_courses(user_model):
-    """
-    Makes an SDK call (_sdk_call transforms user model into canvas_python_sdk
-    request context)
-    :param user_model: instance of canvas_adapter.models.CanvasUser
-    :return: results of _get_active_courses()
-    """
-    return _sdk_call(user_model, _get_active_courses)
-
-
-def _get_active_courses(context):
-    """
-    Gets a full list of courses for which the user has a teacher or designer
-    role and which are either unpublished or available (i.e. not completed or
-    deleted).
-    :param context: request context required by canvas_python_sdk
-    :return: list of dicts representing Canvas courses (see
-    https://canvas.instructure.com/doc/api/courses.html#Course)
-    """
-    lst = get_all_list_data(
-        context,
-        courses.list_your_courses,
-        include='term',
-        state=['unpublished', 'available']
-    )
-    course_list = []
-    for c in lst:
-        for e in c['enrollments']:
-            if e['type'] in ['teacher', 'designer']:
-                course_list.append(c)
-                break
-    log.info("Found {} active courses.".format(len(course_list)))
-    return course_list
-
-
-def get_course(user_model, course_id):
-    return _sdk_call(user_model, _get_course, course_id=course_id)
-
-
-def _get_course(context, course_id):
-    url = "{}/v1/courses/{}?include[]=syllabus_body&include[]=term".format(
-        context.base_api_url, course_id
-    )
-    response = requests.get(
-        url, headers={"Authorization": "Bearer {}".format(context.auth_token)}
-    )
-    if response.status_code != 200:
-        if response.status_code == 401 and 'WWW-Authenticate' in response.headers:
-            raise InvalidOAuthTokenError(
-                "OAuth Token used to make request to %s is invalid" % response.url)
-        raise CanvasAPIError(
-            status_code=response.status_code,
-            msg=unicode(response.json()),
-            error_json=response.json(),
+    @staticmethod
+    def _get_pages(context, course_id):
+        page_list = get_all_list_data(
+            context, pages.list_pages_courses, course_id
         )
-    return response.json()
+        for page in page_list:
+            details = pages.show_page_courses(
+                context, course_id, page['url']
+            )
+            page['body'] = details.json()['body']
+        return page_list
 
 
-def get_pages(user_model, course_id):
-    return _sdk_call(user_model, _get_pages, course_id=course_id)
+    def get_quizzes(self, course_id):
+        return self._sdk_call(self._get_quizzes, course_id=course_id)
 
 
-def _get_pages(context, course_id):
-    page_list = get_all_list_data(
-        context, pages.list_pages_courses, course_id
-    )
-    for page in page_list:
-        details = pages.show_page_courses(
-            context, course_id, page['url']
+    @staticmethod
+    def _get_quizzes(context, course_id):
+        quiz_list = get_all_list_data(
+            context, quizzes.list_quizzes_in_course, course_id
         )
-        page['body'] = details.json()['body']
-    return page_list
+        for quiz in quiz_list:
+            details = get_all_list_data(
+                context, quiz_questions.list_questions_in_quiz,
+                course_id=course_id,
+                quiz_id=quiz['id']
+            )
+            quiz['questions'] = details
+        return quiz_list
 
 
-def get_quizzes(user_model, course_id):
-    return _sdk_call(user_model, _get_quizzes, course_id=course_id)
-
-
-def _get_quizzes(context, course_id):
-    quiz_list = get_all_list_data(
-        context, quizzes.list_quizzes_in_course, course_id
-    )
-    for quiz in quiz_list:
-        details = get_all_list_data(
-            context, quiz_questions.list_questions_in_quiz,
-            course_id=course_id,
-            quiz_id=quiz['id']
-        )
-        quiz['questions'] = details
-    return quiz_list
-
-
-def get_default_module_id(user_model, course_id):
-    return _sdk_call(user_model, _get_default_module_id, course_id=course_id)
-
-
-def _get_default_module_id(context, course_id):
-    module_list = get_all_list_data(context, modules.list_modules,
-                                    course_id, 'items')
-    module_id = next((x['id'] for x in module_list if x.get(
-        'name', None) == settings.CANVAS_IMPORT_MODULE_NAME), None)
-    if not module_id:
-        response = modules.create_module(context, course_id,
-                                         settings.CANVAS_IMPORT_MODULE_NAME)
-        module_id = response.json()['id']
-    return module_id
-
-
-def create_url_module_item(user_model, course_id, module_id, url, title):
-    return _sdk_call(
-        user_model, _create_url_module_item,
-        course_id=course_id, module_id=module_id, url=url, title=title
-    )
-
-
-def _create_url_module_item(context, course_id, module_id, url, title):
-    modules.create_module_item(
-        request_ctx=context,
-        course_id=course_id,
-        module_id=module_id,
-        module_item_type='ExternalUrl',
-        module_item_content_id=None,
-        module_item_external_url=url,
-        module_item_title=title
-    )
-
-
-def _get_context(api_token):
-    api_config = settings.CANVAS_SDK_SETTINGS.copy()
-    api_config['auth_token'] = api_token
-    return RequestContext(**api_config)
+    def _get_context(self, api_token):
+        api_config = CANVAS_SDK_SETTINGS.copy()
+        api_config['auth_token'] = api_token
+        api_config['base_api_url'] = '{}/api'.format(self.url_base)
+        return RequestContext(**api_config)

--- a/example.py
+++ b/example.py
@@ -1,0 +1,20 @@
+# example for using dart_canvas_parser package
+from collections import namedtuple
+from dart_canvas_parser.parser import CanvasParser
+from dart_sdk.models.canvas_content_source import CanvasContentSource
+
+import secure
+
+content_source = CanvasContentSource(
+    default_license = {
+            'text_url':'PLACEHOLDER',
+            'name': 'PLACEHOLDER',
+            'uid': 'PLACEHOLDER'
+        },
+    uid = 'PLACEHOLDER',
+    user_uid = 'PLACEHOLDER',
+)
+
+canvas_parser = CanvasParser(content_source, secure.CANVAS_URL_BASE, secure.CANVAS_API_TOKEN)
+
+parsed = canvas_parser.parse(course_ids=[secure.CANVAS_COURSE_ID])

--- a/example.py
+++ b/example.py
@@ -1,5 +1,4 @@
 # example for using dart_canvas_parser package
-from collections import namedtuple
 from dart_canvas_parser.parser import CanvasParser
 from dart_sdk.models.canvas_content_source import CanvasContentSource
 

--- a/secure.example.py
+++ b/secure.example.py
@@ -1,0 +1,3 @@
+CANVAS_API_TOKEN = "abc123"
+CANVAS_URL_BASE = "https://canvas.harvard.edu"
+CANVAS_COURSE_ID = 7566


### PR DESCRIPTION
This PR is a proof-of-concept for separating out the parsing functionality from [dart-canvas-adapter](https://github.com/harvard-vpal/dart-canvas-adapter) and enabling it to run as a standalone parser, intentionally keeping modifications to the parsing code itself to a minimum. The idea is that this parser can be used as a library to parse a canvas course without needing to run the whole DART service constellation or even having to stand up the canvas adapter application, and the canvas adapter could be adjusted to use this parser as a library dependency.

Modifications made include
* passing the settings (e.g. canvas api token, canvas base url) in instead of relying on django settings variables
* Wrapping the canvas api functions in a CanvasApi class (might have not been necessary)
* Taking out extra functionality not needed for the parser (see note below)

The `canvas_api` module in the adapter included functionality that isn't as relevant to an independent parser (e.g. get all courses or resource type belonging to the canvas user, or getting the default module to use for importing DART assets into a canvas course), these are removed since  I think it makes sense for these to live in the canvas-adapter (or even a canvas-reuse specific service) rather than an independent parser.

There's an example script, `example.py` to show how a parsing job gets called. It assumes that there is a `secure.py` file in the same folder with variables `CANVAS_API_TOKEN`, `CANVAS_URL_BASE` and `CANVAS_COURSE_ID` populated; `secure.example.py` provides an example. The calling script and inspection of the parsed result also reveals some implications of using the underlying dart_sdk models, i.e. having to specify placeholder license information and uids, and generation of uids for the canvas assets, which I think change every time the parser job happens.